### PR TITLE
Update README.md

### DIFF
--- a/vuepress/docs/docs/README.md
+++ b/vuepress/docs/docs/README.md
@@ -44,7 +44,7 @@ Let's create a case class named `Queries` that will represent our API, with 2 fi
 
 ```scala
 // schema
-case class CharacterName(name: String)
+case class Character(name: String)
 case class Queries(characters: List[Character],
                    character: CharacterName => Option[Character])
 // resolver
@@ -93,9 +93,7 @@ Use `ResponseValue#toString` to get the JSON representation of the result.
 ```scala
 val query = """
   {
-    characters {
-      name
-    }
+    characters 
   }"""
 
 for {


### PR DESCRIPTION
name at lines 37 and 47 should be the same, hence both `Character`.

I am less confident about my proposed change at lines 94-98. Given API at lines 72-75, we may request all characters using plural form `characters` without name or we may request a single character in singular form `character` and specify additionally the name as parameter. The current form seems to be a mix of the two forms instead of choosing one correctly. If we want to specify a single character I'd suggest changing `name` to `Pierre` or some common given name.